### PR TITLE
Refactor 'generated' module

### DIFF
--- a/src/generated/info/mod.rs
+++ b/src/generated/info/mod.rs
@@ -46,20 +46,20 @@ impl From<&pb::Version> for Version {
 }
 
 #[derive(PartialEq, Clone, Debug, thiserror::Error)]
-pub enum InfoError {
+pub enum Error {
     #[error("Unknown error: {0}")]
     Unknown(String),
     #[error("Information not yet received: {0}")]
     InformationNotReceivedYet(String),
 }
 
-impl From<InfoError> for RequestError<InfoError> {
-    fn from(e: InfoError) -> Self {
+impl From<Error> for RequestError<Error> {
+    fn from(e: Error) -> Self {
         Self::Mav(e)
     }
 }
 
-pub type GetVersionResult = RequestResult<Version, InfoError>;
+pub type GetVersionResult = RequestResult<Version, Error>;
 
 impl FromRpcResponse<pb::GetVersionResponse> for GetVersionResult {
     fn from_rpc_response(rpc_get_version_response: TonicResult<pb::GetVersionResponse>) -> Self {
@@ -67,21 +67,21 @@ impl FromRpcResponse<pb::GetVersionResponse> for GetVersionResult {
 
         let rpc_info_result = get_version_response
             .info_result
-            .ok_or_else(|| InfoError::Unknown("InfoResult does not received".into()))?;
+            .ok_or_else(|| Error::Unknown("InfoResult does not received".into()))?;
 
         let info_result = pb::info_result::Result::from_i32(rpc_info_result.result)
-            .ok_or_else(|| InfoError::Unknown("Unsupported InfoResult.result value".into()))?;
+            .ok_or_else(|| Error::Unknown("Unsupported InfoResult.result value".into()))?;
 
         match info_result {
             pb::info_result::Result::Success => match get_version_response.version {
                 Some(ref rpc_version) => Ok(Version::from(rpc_version)),
-                None => Err(InfoError::Unknown("Version does not received".into()).into()),
+                None => Err(Error::Unknown("Version does not received".into()).into()),
             },
             pb::info_result::Result::Unknown => {
-                Err(InfoError::Unknown(rpc_info_result.result_str).into())
+                Err(Error::Unknown(rpc_info_result.result_str).into())
             }
             pb::info_result::Result::InformationNotReceivedYet => {
-                Err(InfoError::InformationNotReceivedYet(rpc_info_result.result_str).into())
+                Err(Error::InformationNotReceivedYet(rpc_info_result.result_str).into())
             }
         }
     }

--- a/src/generated/info/mod.rs
+++ b/src/generated/info/mod.rs
@@ -102,10 +102,9 @@ impl Info {
 
 #[tonic::async_trait]
 impl super::super::Connect for Info {
-    async fn connect(url: &String) -> std::result::Result<Info, tonic::transport::Error> {
+    async fn connect(url: String) -> std::result::Result<Info, tonic::transport::Error> {
         Ok(Info {
-            service_client: pb::info_service_client::InfoServiceClient::connect(url.clone())
-                .await?,
+            service_client: pb::info_service_client::InfoServiceClient::connect(url).await?,
         })
     }
 }

--- a/src/generated/mocap/mod.rs
+++ b/src/generated/mocap/mod.rs
@@ -306,10 +306,9 @@ impl Mocap {
 
 #[tonic::async_trait]
 impl super::super::Connect for Mocap {
-    async fn connect(url: &String) -> std::result::Result<Mocap, tonic::transport::Error> {
+    async fn connect(url: String) -> std::result::Result<Mocap, tonic::transport::Error> {
         Ok(Mocap {
-            service_client: pb::mocap_service_client::MocapServiceClient::connect(url.clone())
-                .await?,
+            service_client: pb::mocap_service_client::MocapServiceClient::connect(url).await?,
         })
     }
 }

--- a/src/generated/mocap/mod.rs
+++ b/src/generated/mocap/mod.rs
@@ -21,13 +21,13 @@ pub struct VisionPositionEstimate {
     pub pose_covariance: Covariance,
 }
 
-impl Into<pb::VisionPositionEstimate> for VisionPositionEstimate {
-    fn into(self) -> pb::VisionPositionEstimate {
-        pb::VisionPositionEstimate {
-            time_usec: self.time_usec,
-            position_body: Some(self.position_body.into()),
-            angle_body: Some(self.angle_body.into()),
-            pose_covariance: Some(self.pose_covariance.into()),
+impl From<VisionPositionEstimate> for pb::VisionPositionEstimate {
+    fn from(est: VisionPositionEstimate) -> Self {
+        Self {
+            time_usec: est.time_usec,
+            position_body: Some(est.position_body.into()),
+            angle_body: Some(est.angle_body.into()),
+            pose_covariance: Some(est.pose_covariance.into()),
         }
     }
 }
@@ -45,13 +45,13 @@ pub struct AttitudePositionMocap {
     pub pose_covariance: Covariance,
 }
 
-impl Into<pb::AttitudePositionMocap> for AttitudePositionMocap {
-    fn into(self) -> pb::AttitudePositionMocap {
-        pb::AttitudePositionMocap {
-            time_usec: self.time_usec,
-            q: Some(self.q.into()),
-            position_body: Some(self.position_body.into()),
-            pose_covariance: Some(self.pose_covariance.into()),
+impl From<AttitudePositionMocap> for pb::AttitudePositionMocap {
+    fn from(attitude_position: AttitudePositionMocap) -> Self {
+        Self {
+            time_usec: attitude_position.time_usec,
+            q: Some(attitude_position.q.into()),
+            position_body: Some(attitude_position.position_body.into()),
+            pose_covariance: Some(attitude_position.pose_covariance.into()),
         }
     }
 }
@@ -77,17 +77,17 @@ pub struct Odometry {
     pub velocity_covariance: Covariance,
 }
 
-impl Into<pb::Odometry> for Odometry {
-    fn into(self) -> pb::Odometry {
-        pb::Odometry {
-            time_usec: self.time_usec,
-            frame_id: self.frame_id,
-            position_body: Some(self.position_body.into()),
-            q: Some(self.q.into()),
-            speed_body: Some(self.speed_body.into()),
-            angular_velocity_body: Some(self.angular_velocity_body.into()),
-            pose_covariance: Some(self.pose_covariance.into()),
-            velocity_covariance: Some(self.velocity_covariance.into()),
+impl From<Odometry> for pb::Odometry {
+    fn from(odometry: Odometry) -> Self {
+        Self {
+            time_usec: odometry.time_usec,
+            frame_id: odometry.frame_id,
+            position_body: Some(odometry.position_body.into()),
+            q: Some(odometry.q.into()),
+            speed_body: Some(odometry.speed_body.into()),
+            angular_velocity_body: Some(odometry.angular_velocity_body.into()),
+            pose_covariance: Some(odometry.pose_covariance.into()),
+            velocity_covariance: Some(odometry.velocity_covariance.into()),
         }
     }
 }
@@ -103,12 +103,12 @@ pub struct PositionBody {
     pub z_m: f32,
 }
 
-impl Into<pb::PositionBody> for PositionBody {
-    fn into(self) -> pb::PositionBody {
-        pb::PositionBody {
-            x_m: self.x_m,
-            y_m: self.y_m,
-            z_m: self.z_m,
+impl From<PositionBody> for pb::PositionBody {
+    fn from(position: PositionBody) -> Self {
+        Self {
+            x_m: position.x_m,
+            y_m: position.y_m,
+            z_m: position.z_m,
         }
     }
 }
@@ -124,12 +124,12 @@ pub struct AngleBody {
     pub yaw_rad: f32,
 }
 
-impl Into<pb::AngleBody> for AngleBody {
-    fn into(self) -> pb::AngleBody {
-        pb::AngleBody {
-            roll_rad: self.roll_rad,
-            pitch_rad: self.pitch_rad,
-            yaw_rad: self.yaw_rad,
+impl From<AngleBody> for pb::AngleBody {
+    fn from(angle: AngleBody) -> Self {
+        Self {
+            roll_rad: angle.roll_rad,
+            pitch_rad: angle.pitch_rad,
+            yaw_rad: angle.yaw_rad,
         }
     }
 }
@@ -145,12 +145,12 @@ pub struct SpeedBody {
     pub z_m_s: f32,
 }
 
-impl Into<pb::SpeedBody> for SpeedBody {
-    fn into(self) -> pb::SpeedBody {
-        pb::SpeedBody {
-            x_m_s: self.x_m_s,
-            y_m_s: self.y_m_s,
-            z_m_s: self.z_m_s,
+impl From<SpeedBody> for pb::SpeedBody {
+    fn from(speed: SpeedBody) -> Self {
+        Self {
+            x_m_s: speed.x_m_s,
+            y_m_s: speed.y_m_s,
+            z_m_s: speed.z_m_s,
         }
     }
 }
@@ -166,12 +166,12 @@ pub struct AngularVelocityBody {
     pub yaw_rad_s: f32,
 }
 
-impl Into<pb::AngularVelocityBody> for AngularVelocityBody {
-    fn into(self) -> pb::AngularVelocityBody {
-        pb::AngularVelocityBody {
-            roll_rad_s: self.roll_rad_s,
-            pitch_rad_s: self.pitch_rad_s,
-            yaw_rad_s: self.yaw_rad_s,
+impl From<AngularVelocityBody> for pb::AngularVelocityBody {
+    fn from(angular_velocity: AngularVelocityBody) -> Self {
+        Self {
+            roll_rad_s: angular_velocity.roll_rad_s,
+            pitch_rad_s: angular_velocity.pitch_rad_s,
+            yaw_rad_s: angular_velocity.yaw_rad_s,
         }
     }
 }
@@ -185,10 +185,10 @@ pub struct Covariance {
     pub covariance_matrix: ::std::vec::Vec<f32>,
 }
 
-impl Into<pb::Covariance> for Covariance {
-    fn into(self) -> pb::Covariance {
-        pb::Covariance {
-            covariance_matrix: self.covariance_matrix,
+impl From<Covariance> for pb::Covariance {
+    fn from(covariance: Covariance) -> Self {
+        Self {
+            covariance_matrix: covariance.covariance_matrix,
         }
     }
 }
@@ -214,13 +214,13 @@ pub struct Quaternion {
     pub z: f32,
 }
 
-impl Into<pb::Quaternion> for Quaternion {
-    fn into(self) -> pb::Quaternion {
-        pb::Quaternion {
-            w: self.w,
-            x: self.x,
-            y: self.y,
-            z: self.z,
+impl From<Quaternion> for pb::Quaternion {
+    fn from(quarternion: Quaternion) -> Self {
+        Self {
+            w: quarternion.w,
+            x: quarternion.x,
+            y: quarternion.y,
+            z: quarternion.z,
         }
     }
 }

--- a/src/generated/mocap/mod.rs
+++ b/src/generated/mocap/mod.rs
@@ -201,7 +201,7 @@ impl From<Covariance> for pb::Covariance {
 /// A zero-rotation quaternion is represented by (1,0,0,0).
 /// The quaternion could also be written as w + xi + yj + zk.
 ///
-/// For more info see: https://en.wikipedia.org/wiki/Quaternion
+/// For more info see: <https://en.wikipedia.org/wiki/Quaternion>
 #[derive(Clone, PartialEq, Debug)]
 pub struct Quaternion {
     /// Quaternion entry 0, also denoted as a

--- a/src/generated/telemetry/mod.rs
+++ b/src/generated/telemetry/mod.rs
@@ -265,11 +265,9 @@ pub type OdometryResult = RequestResult<Odometry, Error>;
 #[tonic::async_trait]
 impl super::super::Connect for Telemetry {
     async fn connect(url: String) -> std::result::Result<Telemetry, tonic::transport::Error> {
-        match pb::telemetry_service_client::TelemetryServiceClient::connect(url).await {
-            Ok(client) => Ok(Telemetry {
-                service_client: client,
-            }),
-            Err(err) => Err(err),
-        }
+        let service_client =
+            pb::telemetry_service_client::TelemetryServiceClient::connect(url).await?;
+
+        Ok(Telemetry { service_client })
     }
 }

--- a/src/generated/telemetry/mod.rs
+++ b/src/generated/telemetry/mod.rs
@@ -263,8 +263,8 @@ pub type OdometryResult = RequestResult<Odometry, TelemetryError>;
 
 #[tonic::async_trait]
 impl super::super::Connect for Telemetry {
-    async fn connect(url: &String) -> std::result::Result<Telemetry, tonic::transport::Error> {
-        match pb::telemetry_service_client::TelemetryServiceClient::connect(url.clone()).await {
+    async fn connect(url: String) -> std::result::Result<Telemetry, tonic::transport::Error> {
+        match pb::telemetry_service_client::TelemetryServiceClient::connect(url).await {
             Ok(client) => Ok(Telemetry {
                 service_client: client,
             }),

--- a/src/generated/telemetry/mod.rs
+++ b/src/generated/telemetry/mod.rs
@@ -86,12 +86,12 @@ impl From<&pb::SpeedBody> for SpeedBody {
     }
 }
 
-impl Into<pb::SpeedBody> for SpeedBody {
-    fn into(self) -> pb::SpeedBody {
-        pb::SpeedBody {
-            velocity_x_m_s: self.velocity_x_m_s,
-            velocity_y_m_s: self.velocity_y_m_s,
-            velocity_z_m_s: self.velocity_z_m_s,
+impl From<SpeedBody> for pb::SpeedBody {
+    fn from(speed: SpeedBody) -> Self {
+        Self {
+            velocity_x_m_s: speed.velocity_x_m_s,
+            velocity_y_m_s: speed.velocity_y_m_s,
+            velocity_z_m_s: speed.velocity_z_m_s,
         }
     }
 }
@@ -117,12 +117,12 @@ impl From<&pb::AngularVelocityBody> for AngularVelocityBody {
     }
 }
 
-impl Into<pb::AngularVelocityBody> for AngularVelocityBody {
-    fn into(self) -> pb::AngularVelocityBody {
-        pb::AngularVelocityBody {
-            roll_rad_s: self.roll_rad_s,
-            pitch_rad_s: self.pitch_rad_s,
-            yaw_rad_s: self.yaw_rad_s,
+impl From<AngularVelocityBody> for pb::AngularVelocityBody {
+    fn from(angular_velocity: AngularVelocityBody) -> Self {
+        Self {
+            roll_rad_s: angular_velocity.roll_rad_s,
+            pitch_rad_s: angular_velocity.pitch_rad_s,
+            yaw_rad_s: angular_velocity.yaw_rad_s,
         }
     }
 }
@@ -133,7 +133,7 @@ impl Into<pb::AngularVelocityBody> for AngularVelocityBody {
 /// Set first to NaN if unknown.
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct Covariance {
-    pub covariance_matrix: ::std::vec::Vec<f32>,
+    pub covariance_matrix: Vec<f32>,
 }
 
 impl From<pb::Odometry> for Odometry {
@@ -144,9 +144,7 @@ impl From<pb::Odometry> for Odometry {
             child_frame_id: MavFrame::from_i32(rpc_odometry.child_frame_id).unwrap(),
             position_body: PositionBody::from(&rpc_odometry.position_body.unwrap()),
             q: Quaternion::from(&rpc_odometry.q.unwrap()),
-            speed_body: SpeedBody::from(
-                &rpc_odometry.speed_body.unwrap_or(pb::SpeedBody::default()),
-            ),
+            speed_body: SpeedBody::from(&rpc_odometry.speed_body.unwrap_or_default()),
             angular_velocity_body: AngularVelocityBody::from(
                 &rpc_odometry.angular_velocity_body.unwrap(),
             ),
@@ -160,10 +158,10 @@ impl From<pb::Odometry> for Odometry {
     }
 }
 
-impl Into<pb::Covariance> for Covariance {
-    fn into(self) -> pb::Covariance {
-        pb::Covariance {
-            covariance_matrix: self.covariance_matrix,
+impl From<Covariance> for pb::Covariance {
+    fn from(covariance: Covariance) -> Self {
+        Self {
+            covariance_matrix: covariance.covariance_matrix,
         }
     }
 }
@@ -200,13 +198,13 @@ impl From<&pb::Quaternion> for Quaternion {
     }
 }
 
-impl Into<pb::Quaternion> for Quaternion {
-    fn into(self) -> pb::Quaternion {
-        pb::Quaternion {
-            w: self.w,
-            x: self.x,
-            y: self.y,
-            z: self.z,
+impl From<Quaternion> for pb::Quaternion {
+    fn from(quarternion: Quaternion) -> Self {
+        Self {
+            w: quarternion.w,
+            x: quarternion.x,
+            y: quarternion.y,
+            z: quarternion.z,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,9 @@ impl System {
         let url = url.unwrap_or_else(|| String::from("http://0.0.0.0:50051"));
 
         let (mocap, info, telemetry) = try_join3(
-            mocap::Mocap::connect(&url),
-            info::Info::connect(&url),
-            telemetry::Telemetry::connect(&url),
+            mocap::Mocap::connect(url.clone()),
+            info::Info::connect(url.clone()),
+            telemetry::Telemetry::connect(url),
         )
         .await?;
 
@@ -52,8 +52,7 @@ impl System {
 
 #[tonic::async_trait]
 trait Connect {
-    #[allow(clippy::ptr_arg)]
-    async fn connect(url: &String) -> Result<Self, tonic::transport::Error>
+    async fn connect(url: String) -> Result<Self, tonic::transport::Error>
     where
         Self: Sized;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-#[allow(clippy::all)]
 mod generated;
 
 use futures_util::future::try_join3;


### PR DESCRIPTION
remove the clippy exemptions and refactor the 'generated' module.

- prefer `From` implementations over `Into` implementions (since the `Into` implementation is then automatically generated)
- change the `Connect` trait to ask for a `String`, instead of asking for a `&String` and immediately cloning it
  - this could be made more flexible (but more verbose) by changing this parameter to `D: TryInto<tonic::transport::Endpoint>`. Thoughts?